### PR TITLE
bootstrap-prefix.sh: using lp64d for riscv profile

### DIFF
--- a/scripts/bootstrap-prefix.sh
+++ b/scripts/bootstrap-prefix.sh
@@ -425,6 +425,7 @@ bootstrap_setup() {
 			;;
 		riscv64-pc-linux-gnu)
 			profile=${profile_linux/ARCH/riscv}
+			profile=${profile/17.0/20.0/rv64gc/lp64d}
 			;;
 		x86_64-pc-linux-gnu)
 			profile=${profile_linux/ARCH/amd64}
@@ -441,6 +442,7 @@ bootstrap_setup() {
 			;;
 		riscv-pc-unknown-linux-gnu)
 			profile=${profile_linux/ARCH/riscv}
+			profile=${profile/17.0/20.0/rv64gc/lp64d}
 			;;
 		aarch64-unknown-linux-gnu)
 			profile=${profile_linux/ARCH/arm64}


### PR DESCRIPTION
Signed-off-by: Atharva <atharvaamritkar@protonmail.com>
Closes: https://github.com/gentoo/prefix/pull/13
Signed-off-by: Sam James <sam@gentoo.org>